### PR TITLE
Make shadow use deps dev alias

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,9 +4,10 @@
       {
           "projectType": "deps.edn",
           "afterCLJReplJackInCode": "(require '[dev.backend.server] :reload) (in-ns 'dev.backend.server) (start! 6003)",
-          "name": "Polylith RealWorld Server REPL (start)",
-          "autoSelectForJackIn": true,
+          "name": "Polylith RealWorld Server REPL (deps.edn)",
           "projectRootPath": ["."],
+          //  "autoSelectForJackIn": true,
+          //  "autoSelectForConnect": true,
           "cljsType": "shadow-cljs",
           "menuSelections": {
               "cljAliases": ["dev"],
@@ -15,12 +16,18 @@
           },
       },
       {
-          "projectType": "deps.edn",
-          "name": "Polylith RealWorld Server REPL (connect)",
-          "autoSelectForConnect": true,
+          "projectType": "shadow-cljs",
+          "afterCLJReplJackInCode": "(require '[dev.backend.server] :reload) (in-ns 'dev.backend.server) (start! 6003)",
+          "name": "Polylith RealWorld Server REPL (shadow-cljs)",
           "projectRootPath": ["."],
+          //  "autoSelectForJackIn": true,
+          //  "autoSelectForConnect": true,
           "cljsType": "shadow-cljs",
-      }
+          "menuSelections": {
+              "cljsLaunchBuilds": [":app"],
+              "cljsDefaultBuild": ":app"
+          },
+      },
   ],
 
   // When autoConnectRepl is set to `true`, you can start the REPL yourself and keep it running

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,4 +1,4 @@
-{:deps true
+{:deps {:aliases [:dev]}
 
  :dev-http {3000 {:root "frontend/projects/app/public"}}
 


### PR DESCRIPTION
The reason the shadow-cljs project type doesn't work is because the shadow.cljs dependency is not used in that case. The dependency is declared in the `:dev` alias. This change is making shadow use this alias, when it is responsible for starting the REPL.

The reason this is important is that shadow-cljs output stays in the jack-in terminal when shadow starts Clojure, While when starting shadow from Clojure, shadow's output appears in the output/REPL window. I certainly prefer the former.

I also edited settings.json so that it is easier to experiment with the two start options. And I removed the connect-only sequences since server start is idempotent. (Yes, I might be the one who introduced separate sequences to begin with. 😄)